### PR TITLE
Fix bug preventing one MDE rip error from bubbling up the async chain.

### DIFF
--- a/src/mainPreload.js
+++ b/src/mainPreload.js
@@ -236,7 +236,7 @@ window.addEventListener('load', () => {
           resolve();
         } else {
           printExitCode('DCG', code);
-          reject();
+          reject(new Error(`DCG failed with exit code: ${code}`));
         }
       });
     });

--- a/src/mainPreload.js
+++ b/src/mainPreload.js
@@ -282,7 +282,7 @@ window.addEventListener('load', () => {
           resolve();
         } else {
           printExitCode('MDE', code);
-          reject(new Error(`Exit code: ${code}`));
+          reject(new Error(`MDE failed with exit code: ${code}`));
         }
       });
     });

--- a/src/mainPreload.js
+++ b/src/mainPreload.js
@@ -282,7 +282,7 @@ window.addEventListener('load', () => {
           resolve();
         } else {
           printExitCode('MDE', code);
-          reject();
+          reject(new Error(`Exit code: ${code}`));
         }
       });
     });


### PR DESCRIPTION
Without passing in an error object to the reject function, it is undefined and not caught. This leaves an output log of the following, and the Start Ripping button remains disabled. This requires killing DARE and establishing the output queue again to rip items.

> 
> Dynamic has no mesh data (D), skipping...
> 
> File extraction readied...
> API rip done!
> MDE exited with code 0
> MDE exited with code 3221226505
> 

With the fix, the output log shows the following with the last line in red:

> 
> Dynamic has no mesh data (D), skipping...
> 
> File extraction readied...
> API rip done!
> MDE exited with code 0
> MDE exited with code 3221226505
> Ripping failed: Error message: MDE failed with exit code:  3221226505
>

And the Start Ripping button is re-enabled.


Also added the fix for when DCG fails. Observed with the recent light.gg DDOS protection issue where DARE is not in a re-enabled state after a DCG error. 
